### PR TITLE
add production db config

### DIFF
--- a/kubernetes/regapp/overlays/prod/kustomization.yml
+++ b/kubernetes/regapp/overlays/prod/kustomization.yml
@@ -11,3 +11,8 @@ bases:
 
 resources:
   - namespace.yml
+  - secrets/pgo-s3-conf.yaml
+  - secrets/pgo-pgbackrest-secrets.yaml
+
+patchesStrategicMerge:
+  - patches/regapp-db.yaml

--- a/kubernetes/regapp/overlays/prod/patches/regapp-db.yaml
+++ b/kubernetes/regapp/overlays/prod/patches/regapp-db.yaml
@@ -1,0 +1,78 @@
+apiVersion: postgres-operator.crunchydata.com/v1beta1
+kind: PostgresCluster
+metadata:
+  name: regapp-postgres-ha
+  namespace: regapp
+spec:
+  image: registry.developers.crunchydata.com/crunchydata/crunchy-postgres:centos8-13.4-1
+  postgresVersion: 13
+  instances:
+    - name: regapp-pgha1
+      replicas: 2
+      dataVolumeClaimSpec:
+        accessModes:
+          - "ReadWriteOnce"
+        resources:
+          requests:
+            storage: 5Gi
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 1
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchLabels:
+                    postgres-operator.crunchydata.com/cluster: regapp-postgres-ha
+                    postgres-operator.crunchydata.com/instance-set: regapp-pgha1
+  backups:
+    pgbackrest:
+      image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbackrest:centos8-2.35-0
+      configuration:
+      - secret:
+          name: pgo-s3-conf
+      # - secret:
+      #     name: pgo-pgbackrest-secrets
+      global:
+        # repo1-cipher-type: aes-256-cbc
+        # repo2-cipher-type: aes-256-cbc
+        repo2-path: /pgbackrest/postgres-operator/regapp-postgres-ha/repo2
+        repo2-s3-uri-style: path
+      manual:
+        repoName: repo2
+        options:
+          - --type=full
+      repos:
+      - name: repo1
+        schedules:
+          full: "0 1 * * *"
+          incremental: "0 */4 * * *"
+        volume:
+          volumeClaimSpec:
+            accessModes:
+            - "ReadWriteOnce"
+            resources:
+              requests:
+                storage: 5Gi
+      - name: repo2
+        schedules:
+          full: "0 1 * * *"
+          incremental: "0 */4 * * *"
+        s3:
+          bucket: "nerc-shift-1-backups"
+          endpoint: "holecs.rc.fas.harvard.edu"
+          region: "us-east-1"
+  proxy:
+    pgBouncer:
+      image: registry.developers.crunchydata.com/crunchydata/crunchy-pgbouncer:centos8-1.15-3
+      replicas: 2
+      affinity:
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution:
+            - weight: 1
+              podAffinityTerm:
+                topologyKey: kubernetes.io/hostname
+                labelSelector:
+                  matchLabels:
+                    postgres-operator.crunchydata.com/cluster: regapp-postgres-ha
+                    postgres-operator.crunchydata.com/role: pgbouncer

--- a/kubernetes/regapp/overlays/prod/secrets/pgo-pgbackrest-secrets.yaml
+++ b/kubernetes/regapp/overlays/prod/secrets/pgo-pgbackrest-secrets.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: external-secrets.io/v1alpha1
+kind: ExternalSecret
+metadata:
+  name: pgo-pgbackrest-secrets
+spec:
+  target:
+    name: pgo-pgbackrest-secrets
+  refreshInterval: "15s"
+  secretStoreRef:
+    name: vault-backend
+    kind: ClusterSecretStore
+  dataFrom:
+    - key: pgbackrest/regapp-postgres-ha/cipher

--- a/kubernetes/regapp/overlays/prod/secrets/pgo-s3-conf.yaml
+++ b/kubernetes/regapp/overlays/prod/secrets/pgo-s3-conf.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: external-secrets.io/v1alpha1
+kind: ExternalSecret
+metadata:
+  name: pgo-s3-conf
+spec:
+  target:
+    name: pgo-s3-conf
+  refreshInterval: "15s"
+  secretStoreRef:
+    name: vault-backend
+    kind: ClusterSecretStore
+  dataFrom:
+    - key: accounts/holecs


### PR DESCRIPTION
- 1 full backup at 1am
- incremental backups every 4hr
- add offsite backup config via S3-compatible storage (ECS)
- add support for taking manual backups to S3 via postgrescluster
annotation
- staged config for client-side encrypted backups via aes-256-cbc with passphrase (have to wait to uncomment until we either schedule a maintenance or rebuild).