### PR TITLE
fix copy/paste typos

### DIFF
--- a/config/logging.py
+++ b/config/logging.py
@@ -9,7 +9,7 @@ from regapp.config.env import ENV
 
 
 # ------------------------------------------------------------------------------
-# ColdFront logging config
+# regapp logging config
 # ------------------------------------------------------------------------------
 
 MESSAGE_TAGS = {

--- a/kubernetes/regapp/base/regapp/regapp-db.yml
+++ b/kubernetes/regapp/base/regapp/regapp-db.yml
@@ -50,5 +50,5 @@ spec:
                 topologyKey: kubernetes.io/hostname
                 labelSelector:
                   matchLabels:
-                    postgres-operator.crunchydata.com/cluster: coldfront-postgres-ha
+                    postgres-operator.crunchydata.com/cluster: regapp-postgres-ha
                     postgres-operator.crunchydata.com/role: pgbouncer


### PR DESCRIPTION
Updating the pod affinity label match/selector given that it only affects scheduling and not execution. None of the resources have this set so this will fix the affinity settings to work next time pods get scheduled. 