### PR TITLE
pre-commit: add -v flag to see which files failed

### DIFF
--- a/.github/workflows/precommit.yaml
+++ b/.github/workflows/precommit.yaml
@@ -28,4 +28,4 @@ jobs:
 
       - name: Run linters
         run: |
-          pre-commit run --all-files
+          pre-commit run --all-files -v


### PR DESCRIPTION
Currently have to run pre-commit locally to see which files are failing the linter. Adding the verbose flag shows the files it failed on.