### PR TITLE
set backup retentions to 30 days

### DIFF
--- a/kubernetes/regapp/overlays/prod/patches/regapp-db.yaml
+++ b/kubernetes/regapp/overlays/prod/patches/regapp-db.yaml
@@ -38,6 +38,8 @@ spec:
         # repo2-cipher-type: aes-256-cbc
         repo2-path: /pgbackrest/postgres-operator/regapp-postgres-ha/repo2
         repo2-s3-uri-style: path
+        repo1-retention-full: "30"
+        repo2-retention-full: "30"
       manual:
         repoName: repo2
         options:


### PR DESCRIPTION
Our full backups are set to run nightly so this will clean up all but the last 30 days of backups (incremental backups get cleaned up based on which full backups they reference).