### PR TITLE
support for bentley and email whitelisting

### DIFF
--- a/kubernetes/regapp/overlays/dev/kustomization.yml
+++ b/kubernetes/regapp/overlays/dev/kustomization.yml
@@ -34,4 +34,4 @@ patchesStrategicMerge:
   - patch_config.yaml
   - patch_configmap.yaml
   - patch_ingress.yaml
-  - patch_authorization_url.yaml
+  - patch_authorization.yaml

--- a/kubernetes/regapp/overlays/dev/patch_authorization.yaml
+++ b/kubernetes/regapp/overlays/dev/patch_authorization.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: oauth2-configmap-kc
+data:
+  OAUTH2_PROXY_EMAIL_DOMAINS: "harvard.edu,bu.edu,mit.edu,bentley.edu,mghpcc.org,.harvard.edu,.bu.edu,.mit.edu,.bentley.edu,.mghpcc.org"
+
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: oauth2-configmap-cilogon
+data:
+  OAUTH2_PROXY_LOGIN_URL: https://cilogon.org/authorize?idphint=urn%3Amace%3Aincommon%3Amit.edu,https%3A%2F%2Ffed.huit.harvard.edu%2Fidp%2Fshibboleth,https%3A%2F%2Fshib.bu.edu%2Fidp%2Fshibboleth,https%3A%2F%2Flogin.microsoftonline.com%2Fcommon%2Foauth2%2Fv2.0%2Fauthorize
+  OAUTH2_PROXY_EMAIL_DOMAINS: "harvard.edu,bu.edu,mit.edu,bentley.edu,mghpcc.org,.harvard.edu,.bu.edu,.mit.edu,.bentley.edu,.mghpcc.org"

--- a/kubernetes/regapp/overlays/dev/patch_authorization_url.yaml
+++ b/kubernetes/regapp/overlays/dev/patch_authorization_url.yaml
@@ -1,7 +1,0 @@
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: oauth2-configmap-cilogon
-data:
-  OAUTH2_PROXY_LOGIN_URL: https://cilogon.org/authorize?idphint=urn%3Amace%3Aincommon%3Amit.edu,https%3A%2F%2Ffed.huit.harvard.edu%2Fidp%2Fshibboleth,https%3A%2F%2Fshib.bu.edu%2Fidp%2Fshibboleth,https%3A%2F%2Fidp.xsede.org%2Fidp%2Fshibboleth,urn%3Amace%3Aincommon%3Arutgers.edu

--- a/kubernetes/regapp/overlays/prod/kustomization.yml
+++ b/kubernetes/regapp/overlays/prod/kustomization.yml
@@ -17,7 +17,7 @@ resources:
 patchesStrategicMerge:
   - patches/regapp-db.yaml
   - patches/ingress.yaml
-  - patches/patch_authorization_url.yaml
+  - patches/patch_authorization.yaml
   - |-
     apiVersion: external-secrets.io/v1alpha1
     kind: ExternalSecret

--- a/kubernetes/regapp/overlays/prod/patches/patch_authorization.yaml
+++ b/kubernetes/regapp/overlays/prod/patches/patch_authorization.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: oauth2-configmap-kc
+data:
+  OAUTH2_PROXY_EMAIL_DOMAINS: "harvard.edu,bu.edu,mit.edu,bentley.edu,mghpcc.org,.harvard.edu,.bu.edu,.mit.edu,.bentley.edu,.mghpcc.org"
+
+
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: oauth2-configmap-cilogon
+data:
+  OAUTH2_PROXY_LOGIN_URL: https://cilogon.org/authorize?idphint=urn%3Amace%3Aincommon%3Amit.edu,https%3A%2F%2Ffed.huit.harvard.edu%2Fidp%2Fshibboleth,https%3A%2F%2Fshib.bu.edu%2Fidp%2Fshibboleth,https%3A%2F%2Flogin.microsoftonline.com%2Fcommon%2Foauth2%2Fv2.0%2Fauthorize
+  OAUTH2_PROXY_EMAIL_DOMAINS: "harvard.edu,bu.edu,mit.edu,bentley.edu,mghpcc.org,.harvard.edu,.bu.edu,.mit.edu,.bentley.edu,.mghpcc.org"

--- a/kubernetes/regapp/overlays/prod/patches/patch_authorization_url.yaml
+++ b/kubernetes/regapp/overlays/prod/patches/patch_authorization_url.yaml
@@ -1,7 +1,0 @@
----
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: oauth2-configmap-cilogon
-data:
-  OAUTH2_PROXY_LOGIN_URL: https://cilogon.org/authorize?idphint=urn%3Amace%3Aincommon%3Amit.edu,https%3A%2F%2Ffed.huit.harvard.edu%2Fidp%2Fshibboleth,https%3A%2F%2Fshib.bu.edu%2Fidp%2Fshibboleth


### PR DESCRIPTION
Changes to support MS/Bentley logons. Whitelisting emails. 
Note this needs to be coordinated with realm changes to mss in mss-keycloak.