### PR TITLE
minor improvement to k8s manifest validation

### DIFF
--- a/ci-scripts/run-kustomize-build.sh
+++ b/ci-scripts/run-kustomize-build.sh
@@ -8,12 +8,21 @@ function run_kustomize() {
   if [ $? -ne 0 ]; then
     echo FAILED
     echo "${out}"
-    exit 1
+    return 1
   else
     echo OK
+    return 0
   fi
 }
 
+failed=0
 for k in $(find ${ROOT_PATH} -iname kustomization.yml -exec dirname {} \;); do
   run_kustomize "${k}"
+  if [ $? != 0 ]; then
+    failed=1;
+  fi
 done
+
+if [ $failed -eq 1 ]; then
+  exit 1
+fi


### PR DESCRIPTION
This updates the script to report the status of all kustomize builds it
finds in the repo vs exiting after the first failure. The script will
exit 1 if any of the builds fail and 0 only if all are successful.