### PR TITLE
remove whitespace from OAUTH2_PROXY_EMAIL_DOMAINS envars

### DIFF
--- a/kubernetes/regapp/overlays/prod/patches/patch_authorization.yaml
+++ b/kubernetes/regapp/overlays/prod/patches/patch_authorization.yaml
@@ -4,8 +4,7 @@ kind: ConfigMap
 metadata:
   name: oauth2-configmap-kc
 data:
-  OAUTH2_PROXY_EMAIL_DOMAINS: "
-    harvard.edu,.harvard.edu,\
+  OAUTH2_PROXY_EMAIL_DOMAINS: "harvard.edu,.harvard.edu,\
     hbs.edu,.hbs.edu,\
     bu.edu,.bu.edu,\
     mit.edu,.mit.edu,\
@@ -40,8 +39,7 @@ data:
     https%3A%2F%2Fidp.wpi.edu%2Fidp%2Fshibboleth,\
     http%3A%2F%2Fgoogle.com%2Faccounts%2Fo8%2Fid,\
     https%3A%2F%2Flogin.microsoftonline.com%2Fcommon%2Foauth2%2Fv2.0%2Fauthorize"
-  OAUTH2_PROXY_EMAIL_DOMAINS: "
-    harvard.edu,.harvard.edu,\
+  OAUTH2_PROXY_EMAIL_DOMAINS: "harvard.edu,.harvard.edu,\
     hbs.edu,.hbs.edu,\
     bu.edu,.bu.edu,\
     mit.edu,.mit.edu,\


### PR DESCRIPTION
Removed whitespace from first entry in OAUTH2_PROXY_EMAIL_DOMAINS  envars which prevents "naked" harvard.edu emails addresses (e.g. foo@harvard.edu) from being accepted.