### PR TITLE
render terms and conditions markdown locally

### DIFF
--- a/config/terms_and_conditions.py
+++ b/config/terms_and_conditions.py
@@ -6,27 +6,24 @@ All rights reserved. No warranty, explicit or implicit, provided.
 
 from regapp.config.env import ENV
 import requests
+import markdown
 import logging
 
 logger = logging.getLogger(__name__)
 
 TERMS_VER = ENV.get_value('REGAPP_TERMS_VERSION', default="v1.0.1")
-TERMS_LOC = ENV.get_value('REGAPP_TERMS_LOCATION', default=f"https://api.github.com/repos/nerc-project/nerc-eulas/contents/regapp_terms.md?ref={TERMS_VER}")
+TERMS_LOC = ENV.get_value('REGAPP_TERMS_LOCATION', default=f"https://raw.githubusercontent.com/nerc-project/nerc-eulas/{TERMS_VER}/EULA.md")
 TERMS_NAME = ENV.get_value('REGAPP_TERMS_NAME', default="NERC Privacy Statement")
 DEFAULT_TERMS_GRACE_DAYS = ENV.int('REGAPP_DEFAULT_TERMS_GRACE_DAYS', default=90)
 
 
 def get_regapp_terms():
     # Fetch the content from TLOC
-    headers = {
-        'Accept': "application/vnd.github.VERSION.html"
-    }
     try:
         r = requests.get(
             TERMS_LOC,
-            headers=headers
         )
-        terms = r.text
+        terms = markdown.markdown(r.text)
     except requests.exceptions.RequestException as re:
         logger.error(f"Error fetching userinfo in requests.get. {re}")
         terms = f"Unable to retrieve terms version {TERMS_VER} from {TERMS_LOC}"

--- a/kubernetes/regapp/base/regapp/configmap.yml
+++ b/kubernetes/regapp/base/regapp/configmap.yml
@@ -16,6 +16,6 @@ data:
   REGAPP_REGAPP_LOG_LEVEL: DEBUG
   REGAPP_REAPER_MAX_AGE: "86400"
   REGAPP_TERMS_VERSION: "v1.0.0"
-  REGAPP_TERMS_LOCATION: "https://api.github.com/repos/nerc-project/nerc-eulas/contents/EULA.md?ref=v1.0.0"
+  REGAPP_TERMS_LOCATION: "https://raw.githubusercontent.com/nerc-project/nerc-eulas/v1.0.0/EULA.md"
   REGAPP_TERMS_NAME: "EULA"
   REGAPP_DEFAULT_TERMS_GRACE_DAYS: "90"

--- a/requirements.in
+++ b/requirements.in
@@ -11,3 +11,4 @@ psycopg2-binary==2.9.1
 pyjwt[crypto]==2.1.0
 requests==2.26.0
 uvicorn[standard]==0.15.0
+Markdown==3.4.1


### PR DESCRIPTION
This avoids needing to hit the github API which has rate limiting in place when used without authentication. If we require github flavored markdown rendering in the future we can update this (and the k8s deployment) to do authenticated calls to the github API.