### PR TITLE
Added University of Rhode Island IdP

### DIFF
--- a/kubernetes/regapp/overlays/dev/patch_authorization.yaml
+++ b/kubernetes/regapp/overlays/dev/patch_authorization.yaml
@@ -20,7 +20,8 @@ data:
     northeastern.edu,.northeastern.edu,\
     wpi.edu,.wpi.edu,\
     redhat.com,.redhat.com,\
-    gmail.com,.gmail.com"
+    gmail.com,.gmail.com,\
+    uri.edu,.uri.edu"
 
 ---
 apiVersion: v1
@@ -38,6 +39,7 @@ data:
     https%3A%2F%2Fshibboleth.umassmed.edu%2Fidp%2Fshibboleth,\
     https%3A%2F%2Fneuidmsso.neu.edu%2Fidp%2Fshibboleth,\
     https%3A%2F%2Fidp.wpi.edu%2Fidp%2Fshibboleth,\
+    https%3A%2F%2Fsso.uri.edu%2Fidp,\
     http%3A%2F%2Fgoogle.com%2Faccounts%2Fo8%2Fid,\
     https%3A%2F%2Flogin.microsoftonline.com%2Fcommon%2Foauth2%2Fv2.0%2Fauthorize"
   OAUTH2_PROXY_EMAIL_DOMAINS: "
@@ -56,4 +58,5 @@ data:
     northeastern.edu,.northeastern.edu,\
     wpi.edu,.wpi.edu,\
     redhat.com,.redhat.com,\
-    gmail.com,.gmail.com"
+    gmail.com,.gmail.com,\
+    uri.edu,.uri.edu"

--- a/kubernetes/regapp/overlays/microk8s/patch_authorization.yaml
+++ b/kubernetes/regapp/overlays/microk8s/patch_authorization.yaml
@@ -19,7 +19,8 @@ data:
     northeastern.edu,.northeastern.edu,\
     wpi.edu,.wpi.edu,\
     redhat.com,.redhat.com,\
-    gmail.com,.gmail.com"
+    gmail.com,.gmail.com,\
+    uri.edu,.uri.edu"
 
 ---
 apiVersion: v1
@@ -37,6 +38,7 @@ data:
     https%3A%2F%2Fshibboleth.umassmed.edu%2Fidp%2Fshibboleth,\
     https%3A%2F%2Fneuidmsso.neu.edu%2Fidp%2Fshibboleth,\
     https%3A%2F%2Fidp.wpi.edu%2Fidp%2Fshibboleth,\
+    https%3A%2F%2Fsso.uri.edu%2Fidp,\
     http%3A%2F%2Fgoogle.com%2Faccounts%2Fo8%2Fid,\
     https%3A%2F%2Flogin.microsoftonline.com%2Fcommon%2Foauth2%2Fv2.0%2Fauthorize"
   OAUTH2_PROXY_EMAIL_DOMAINS: "harvard.edu,.harvard.edu,\
@@ -54,4 +56,5 @@ data:
     northeastern.edu,.northeastern.edu,\
     wpi.edu,.wpi.edu,\
     redhat.com,.redhat.com,\
-    gmail.com,.gmail.com"
+    gmail.com,.gmail.com,\
+    uri.edu,.uri.edu"

--- a/kubernetes/regapp/overlays/prod/patches/patch_authorization.yaml
+++ b/kubernetes/regapp/overlays/prod/patches/patch_authorization.yaml
@@ -18,7 +18,8 @@ data:
     umb.edu,.umb.edu,\
     northeastern.edu,.northeastern.edu,\
     wpi.edu,.wpi.edu,\
-    redhat.com,.redhat.com"
+    redhat.com,.redhat.com,
+    uri.edu,.uri.edu"
 
 
 ---
@@ -37,6 +38,7 @@ data:
     https%3A%2F%2Fshibboleth.umassmed.edu%2Fidp%2Fshibboleth,\
     https%3A%2F%2Fneuidmsso.neu.edu%2Fidp%2Fshibboleth,\
     https%3A%2F%2Fidp.wpi.edu%2Fidp%2Fshibboleth,\
+    https%3A%2F%2Fsso.uri.edu%2Fidp,\
     http%3A%2F%2Fgoogle.com%2Faccounts%2Fo8%2Fid,\
     https%3A%2F%2Flogin.microsoftonline.com%2Fcommon%2Foauth2%2Fv2.0%2Fauthorize"
   OAUTH2_PROXY_EMAIL_DOMAINS: "harvard.edu,.harvard.edu,\
@@ -53,4 +55,5 @@ data:
     umb.edu,.umb.edu,\
     northeastern.edu,.northeastern.edu,\
     wpi.edu,.wpi.edu,\
-    redhat.com,.redhat.com"
+    redhat.com,.redhat.com,\
+    uri.edu,.uri.edu"


### PR DESCRIPTION
Remember that we need to add https://sso.uri.edu/idp to the authorization URLs for the cilogon identity provider in the running keycloak (mss domain) when we deploy. 

Keycloak operator will not pickup realm changes (parallel commit in mss-keycloak) as those are only read on initial CR processing.