### PR TITLE
add codeforboston.org to email domain whitelist

### DIFF
--- a/kubernetes/regapp/overlays/prod/patches/patch_authorization.yaml
+++ b/kubernetes/regapp/overlays/prod/patches/patch_authorization.yaml
@@ -19,7 +19,8 @@ data:
     northeastern.edu,.northeastern.edu,\
     wpi.edu,.wpi.edu,\
     redhat.com,.redhat.com,\
-    uri.edu,.uri.edu"
+    uri.edu,.uri.edu,\
+    codeforboston.org,.codeforboston.org"
 
 
 ---
@@ -56,4 +57,5 @@ data:
     northeastern.edu,.northeastern.edu,\
     wpi.edu,.wpi.edu,\
     redhat.com,.redhat.com,\
-    uri.edu,.uri.edu"
+    uri.edu,.uri.edu,\
+    codeforboston.org,.codeforboston.org"


### PR DESCRIPTION
Allows logins via Google IdP with `codeforboston.org` email domains.