### PR TITLE
CI/CD: upgrade pre-commit's flake8 to latest v6.1.0 and fix lint errors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,7 +41,7 @@ repos:
       exclude: .*/tests/.*
 
   - repo: https://github.com/pycqa/flake8
-    rev: '4.0.1'
+    rev: '6.1.0'
     hooks:
     - id: flake8
       args:

--- a/apps/regapp/views/utils.py
+++ b/apps/regapp/views/utils.py
@@ -81,7 +81,7 @@ def get_user_confirmation(account_action, validation_email):
         # This should not happen...
         errmsg = (
             "Account action has unrecognized "
-            f"opcode { account_action.opcode }"
+            f"opcode {account_action.opcode}"
         )
         logger.error(errmsg)
         raise RuntimeError(errmsg)


### PR DESCRIPTION
 The previous 4.0.1 version of flake8 now hits the following error due to importlib-metadata >= 5.0.0 removing compatibility shims for deprecated entry point interfaces:
```
AttributeError: 'EntryPoints' object has no attribute 'get'
```
See: https://importlib-metadata.readthedocs.io/en/latest/history.html#v5-0-0

Upgrading to the latest version gets around this issue with newer importlib-metadata version.

After upgrading flake8 now appears to be more strict about format string variables (no spaces after/before curly braces).