### PR TITLE
nerc-shift-1: bump pgha storage to 11Gi

### DIFF
--- a/kubernetes/regapp/overlays/prod/patches/regapp-db.yaml
+++ b/kubernetes/regapp/overlays/prod/patches/regapp-db.yaml
@@ -14,7 +14,7 @@ spec:
           - "ReadWriteOnce"
         resources:
           requests:
-            storage: 5Gi
+            storage: 11Gi
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:


### PR DESCRIPTION
The pgha data volumes filled up - bumping to 11Gi for now.